### PR TITLE
show a map on the location edit dialog

### DIFF
--- a/app/qml/dialogs/LocationEditDialog.qml
+++ b/app/qml/dialogs/LocationEditDialog.qml
@@ -16,6 +16,25 @@ Dialog {
     PositionSource {
         id: positionSource
         active: true
+        onPositionChanged: {
+            map.updateSourcePoint("gps", position.coordinate.latitude, position.coordinate.longitude, qsTrId("id-use-current-position"))
+
+            if (position.latitudeValid) {
+                map.addLayer("gps-uncertainty", {"type": "circle", "source": "gps"}, "initial-point")
+                map.setPaintProperty("gps-uncertainty", "circle-radius", position.horizontalAccuracy && position.horizontalAccuracy < 100 ? position.horizontalAccuracy : 100)
+                map.setPaintProperty("gps-uncertainty", "circle-color", "#87cefa")
+                map.setPaintProperty("gps-uncertainty", "circle-opacity", 0.25)
+
+                map.addLayer("gps-case", {"type": "circle", "source": "gps"})
+                map.setPaintProperty("gps-case", "circle-radius", 10)
+                map.setPaintProperty("gps-case", "circle-color", "white")
+            }
+            else {
+                map.addLayer("gps-case", {"type": "circle", "source": "gps"})
+                map.setPaintProperty("gps-case", "circle-radius", 10)
+                map.setPaintProperty("gps-case", "circle-color", "grey")
+            }
+        }
     }
 
     Column {
@@ -159,11 +178,16 @@ Dialog {
                 activeDoubleClickedGeo: true
 
                 onClickedGeo: {
-                    if (Math.abs(geocoordinate.latitude - latitude) < 5 * degLatPerPixel &&
-                            Math.abs(geocoordinate.longitude - longitude) < 5 * degLonPerPixel) {
+                    if (Math.abs(geocoordinate.latitude - latitude) < 10 * degLatPerPixel &&
+                            Math.abs(geocoordinate.longitude - longitude) < 10 * degLonPerPixel) {
                         latitudeField.text = latitude
                         longitudeField.text = longitude
                     }
+                    else if (Math.abs(geocoordinate.latitude - positionSource.position.coordinate.latitude) < 10 * degLatPerPixel &&
+                                Math.abs(geocoordinate.longitude - positionSource.position.coordinate.longitude) < 10 * degLonPerPixel) {
+                            latitudeField.text = positionSource.position.coordinate.latitude
+                            longitudeField.text = positionSource.position.coordinate.longitude
+                        }
                     else {
                         latitudeField.text = geocoordinate.latitude
                         longitudeField.text = geocoordinate.longitude

--- a/app/qml/dialogs/LocationEditDialog.qml
+++ b/app/qml/dialogs/LocationEditDialog.qml
@@ -20,17 +20,17 @@ Dialog {
             map.updateSourcePoint("gps", position.coordinate.latitude, position.coordinate.longitude, qsTrId("id-use-current-position"))
 
             if (position.latitudeValid) {
-                map.addLayer("gps-uncertainty", {"type": "circle", "source": "gps"}, "initial-point")
+                map.addLayer("gps-uncertainty", {"type": "circle", "source": "gps"}, "gps-case")
                 map.setPaintProperty("gps-uncertainty", "circle-radius", position.horizontalAccuracy && position.horizontalAccuracy < 100 ? position.horizontalAccuracy : 100)
                 map.setPaintProperty("gps-uncertainty", "circle-color", "#87cefa")
                 map.setPaintProperty("gps-uncertainty", "circle-opacity", 0.25)
 
-                map.addLayer("gps-case", {"type": "circle", "source": "gps"})
+                map.addLayer("gps-case", {"type": "circle", "source": "gps"}, "initial-point")
                 map.setPaintProperty("gps-case", "circle-radius", 10)
                 map.setPaintProperty("gps-case", "circle-color", "white")
             }
             else {
-                map.addLayer("gps-case", {"type": "circle", "source": "gps"})
+                map.addLayer("gps-case", {"type": "circle", "source": "gps"}, "initial-point")
                 map.setPaintProperty("gps-case", "circle-radius", 10)
                 map.setPaintProperty("gps-case", "circle-color", "grey")
             }

--- a/app/qml/dialogs/LocationEditDialog.qml
+++ b/app/qml/dialogs/LocationEditDialog.qml
@@ -98,8 +98,7 @@ Dialog {
                 longitudeField.text = positionSource.position.coordinate.longitude
 
                 map.fitView([
-                                QtPositioning.coordinate(latitude, longitude),
-                                QtPositioning.coordinate(position.coordinate.latitude, position.coordinate.longitude)
+                                QtPositioning.coordinate(positionSource.position.coordinate.latitude, positionSource.position.coordinate.longitude)
                             ])
             }
         }

--- a/app/qml/dialogs/LocationEditDialog.qml
+++ b/app/qml/dialogs/LocationEditDialog.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.2
 import Sailfish.Silica 1.0
 import QtPositioning 5.0
+import MapboxMap 1.0
 
 Dialog {
     property bool edit: true
@@ -76,6 +77,11 @@ Dialog {
             onClicked: {
                 latitudeField.text = positionSource.position.coordinate.latitude
                 longitudeField.text = positionSource.position.coordinate.longitude
+
+                map.fitView([
+                                QtPositioning.coordinate(latitude, longitude),
+                                QtPositioning.coordinate(position.coordinate.latitude, position.coordinate.longitude)
+                            ])
             }
         }
 
@@ -99,6 +105,8 @@ Dialog {
 
             onTextChanged: {
                 text = text.replace(',', '.')
+
+                map.updateSourcePoint("userinput", latitudeField.text, longitudeField.text, name)
             }
 
             EnterKey.iconSource: "image://theme/icon-m-enter-next"
@@ -125,10 +133,76 @@ Dialog {
 
             onTextChanged: {
                 text = text.replace(',', '.')
+                map.updateSourcePoint("userinput", latitudeField.text, longitudeField.text, name)
             }
 
             EnterKey.iconSource: "image://theme/icon-m-enter-close"
             EnterKey.onClicked: longitudeField.focus = false
+        }
+
+        MapboxMap {
+
+            id: map
+            width: parent.width
+            height: width
+
+            minimumZoomLevel: 0
+            maximumZoomLevel: 20
+            pixelRatio: 3.0
+            accessToken: settings.mapboxApiKey.length > 0 ? settings.mapboxApiKey : dbusService.getProperty("mapBoxApiKey")
+            cacheDatabaseDefaultPath: true
+
+            MapboxMapGestureArea {
+                id: mouseArea
+                map: map
+                activeClickedGeo: true
+                activeDoubleClickedGeo: true
+
+                onClickedGeo: {
+                    if (Math.abs(geocoordinate.latitude - latitude) < 5 * degLatPerPixel &&
+                            Math.abs(geocoordinate.longitude - longitude) < 5 * degLonPerPixel) {
+                        latitudeField.text = latitude
+                        longitudeField.text = longitude
+                    }
+                    else {
+                        latitudeField.text = geocoordinate.latitude
+                        longitudeField.text = geocoordinate.longitude
+                    }
+
+                    map.fitView([
+                                    QtPositioning.coordinate(geocoordinate.latitude, geocoordinate.longitude),
+                                ])
+                }
+
+            }
+
+            Component.onCompleted: {
+                setMargins(0.1, 0.1, 0.1, 0.1)
+
+                map.addSourcePoint("initial", latitude, longitude, name)
+                map.addSourcePoint("userinput", latitudeField.text, longitudeField.text, name)
+
+                map.addLayer("initial-point", {"type": "circle", "source": "initial"}, "userinput-point")
+                map.setPaintProperty("initial-point", "circle-radius", 5)
+                map.setPaintProperty("initial-point", "circle-color", "green")
+
+                map.addLayer("userinput-point", {"type": "circle", "source": "userinput"})
+                map.setPaintProperty("userinput-point", "circle-radius", 5)
+                map.setPaintProperty("userinput-point", "circle-color", "blue")
+
+                map.addLayer("userinput-label", {"type": "symbol", "source": "userinput"})
+                map.setLayoutProperty("userinput-label", "text-field", "{name}")
+                map.setLayoutProperty("userinput-label", "text-justify", "left")
+                map.setLayoutProperty("userinput-label", "text-anchor", "top-left")
+                map.setLayoutPropertyList("userinput-label", "text-offset", [0.2, 0.2])
+                map.setPaintProperty("userinput-label", "text-halo-color", "white")
+                map.setPaintProperty("userinput-label", "text-halo-width", 1)
+
+                map.fitView([
+                                QtPositioning.coordinate(latitude - 0.5, longitude - 0.5),
+                                QtPositioning.coordinate(latitude + 0.5, longitude + 0.5),
+                            ])
+            }
         }
 
     }


### PR DESCRIPTION
this adds an interactive map to the location edit dialog with the current gps position, the initially chosen location and the current user chosen location. It is also interactive, so one can modify the user chosen location by clicking on the map.